### PR TITLE
Voice WebRTC signaling specification

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,45 +6,51 @@ This repository contains the complete technical specification for building Inten
 
 ## Contents
 
-- **REST API** - HTTP endpoints, request/response formats
-- **Gateway** - WebSocket protocol, opcodes, events
-- **Voice** - WebRTC signaling, SDP/ICE exchange
-- **Encryption** - MLS E2EE specification
-- **Webhooks** - Webhook payload formats, Discord compatibility
-- **Discord Mapping** - API equivalences for migration
+### REST API (`rest-api/`)
+- [**Resources**](rest-api/resources.md) — Servers, channels, messages CRUD with full endpoint specs
+- [**Authentication**](rest-api/authentication.md) — Token types, permission bitfields, OAuth2 outline
+- [**Rate Limiting**](rest-api/rate-limiting.md) — Per-route buckets, global limits, response headers
+
+### Gateway (`gateway/`)
+- [**Opcodes**](gateway/opcodes.md) — 13 opcodes (0-12), connection lifecycle, heartbeat, resume
+- [**Events**](gateway/events.md) — 15 event types with payload schemas and examples
+- [**MessagePack**](gateway/messagepack.md) — Binary encoding spec, type mappings, wire format, client examples
+
+### Voice (`voice/`)
+- [**Signaling**](voice/signaling.md) — WebRTC SFU architecture, connection lifecycle, STUN/TURN, speaking indicators
+- [**Codecs**](voice/codecs.md) — Opus configuration, RTP header extensions, RTCP feedback, bitrate profiles
+
+### Encryption (`encryption/`)
+- [**MLS E2EE**](encryption/mls-spec.md) — MLS (RFC 9420) for encrypted DMs, key packages, ciphersuite selection
+
+### Webhooks (`webhooks/`)
+- [**Format**](webhooks/format.md) — Webhook payloads, Discord-compatible endpoint format
+
+### Discord Mapping (`discord-mapping/`)
+- [**Endpoints**](discord-mapping/endpoints.md) — REST endpoint equivalences
+- [**Events**](discord-mapping/events.md) — Gateway event name mapping
+- [**Objects**](discord-mapping/objects.md) — Object field mapping
+
+### Schemas (`schemas/`)
+- [**OpenAPI 3.1**](schemas/openapi.yaml) — Machine-readable spec for code generation and validation
 
 ## Purpose
 
 This spec enables:
 - Third-party client development
-- Bot SDK implementation
+- Bot SDK implementation (see [intent.js](https://github.com/IntentAi/intent.js), [intent.py](https://github.com/IntentAi/intent.py))
 - Integration tools
 - Migration from Discord
 
 ## Status
 
- **Work in Progress** - Being extracted from server implementation.
-
-Documentation is being added incrementally as components are finalized.
-
-## Structure
-
-```
-intent-protocol/
-├── rest-api/      # REST API specification
-├── gateway/      # WebSocket protocol
-├── voice/       # Voice/WebRTC specs
-├── encryption/     # E2EE specifications
-├── webhooks/      # Webhook formats
-├── discord-mapping/  # Discord API equivalences
-└── schemas/      # JSON schemas
-```
+Phase 1 specification is near-complete. REST API, gateway protocol, voice signaling, and encryption specs are documented. Opcodes 0-3 and 11 are implemented server-side; remaining opcodes (4-10, 12) are specified for future implementation.
 
 ## Contributing
 
 See [CONTRIBUTING.md](CONTRIBUTING.md)
 
-Protocol documentation contributions are welcome!
+Protocol documentation contributions are welcome.
 
 ## License
 

--- a/gateway/events.md
+++ b/gateway/events.md
@@ -373,7 +373,7 @@ Dispatched when a user's presence changes.
 
 ### VOICE_STATE_UPDATE
 
-Dispatched when someone joins, leaves, or updates voice state.
+Dispatched when someone joins, leaves, or changes voice state in a server you're in. Broadcast to all members of the server.
 
 **Planned payload:**
 
@@ -381,27 +381,123 @@ Dispatched when someone joins, leaves, or updates voice state.
 {
   user_id: string,
   server_id: string,
-  channel_id: string | null,  // null if leaving
+  channel_id: string | null,  // null when disconnecting
+  session_id: string,         // stable across mute/deaf toggles, changes on rejoin
   self_mute: boolean,
   self_deaf: boolean,
-  server_mute: boolean,
-  server_deaf: boolean
+  server_mute: boolean,       // set by MUTE_MEMBERS permission holders
+  server_deaf: boolean        // set by DEAFEN_MEMBERS permission holders
 }
 ```
 
+**Example — user joins voice:**
+
+```json
+{
+  "op": 0,
+  "t": "VOICE_STATE_UPDATE",
+  "s": 58,
+  "d": {
+    "user_id": "9876543210",
+    "server_id": "1234567890",
+    "channel_id": "5555555555",
+    "session_id": "vs_f7a2c1d8e3b9",
+    "self_mute": false,
+    "self_deaf": false,
+    "server_mute": false,
+    "server_deaf": false
+  }
+}
+```
+
+**Example — user disconnects:**
+
+```json
+{
+  "op": 0,
+  "t": "VOICE_STATE_UPDATE",
+  "s": 59,
+  "d": {
+    "user_id": "9876543210",
+    "server_id": "1234567890",
+    "channel_id": null,
+    "session_id": "vs_f7a2c1d8e3b9",
+    "self_mute": false,
+    "self_deaf": false,
+    "server_mute": false,
+    "server_deaf": false
+  }
+}
+```
+
+**Triggers:**
+- User sends opcode 4 to join, move, or leave a voice channel
+- User toggles self-mute or self-deaf
+- Admin mutes/deafens a user (requires `MUTE_MEMBERS` / `DEAFEN_MEMBERS`)
+- Admin moves a user to another channel (requires `MOVE_MEMBERS`)
+- User disconnects ungracefully (SFU timeout after 15 seconds)
+
 ### VOICE_SERVER_UPDATE
 
-Dispatched to provide voice connection info.
+Dispatched privately to a user after they send opcode 4 to join a voice channel. Contains everything needed to establish the WebRTC connection with the SFU.
 
 **Planned payload:**
 
 ```typescript
 {
   server_id: string,
-  endpoint: string,    // Voice server URL
-  token: string        // Voice connection token
+  channel_id: string,
+  endpoint: string,          // SFU WebSocket URL
+  token: string,             // single-use voice token, valid 60 seconds
+  ice_servers: IceServer[]   // STUN/TURN configuration for NAT traversal
 }
 ```
+
+**IceServer structure:**
+
+```typescript
+{
+  urls: string[],            // e.g. ["stun:stun.intent.chat:3478"]
+  username?: string,         // TURN only, time-limited credential
+  credential?: string        // TURN only, HMAC-based secret
+}
+```
+
+**Example:**
+
+```json
+{
+  "op": 0,
+  "t": "VOICE_SERVER_UPDATE",
+  "s": 59,
+  "d": {
+    "server_id": "1234567890",
+    "channel_id": "5555555555",
+    "endpoint": "wss://us-east.voice.intent.chat",
+    "token": "vt_a8f3bc91d2e4...",
+    "ice_servers": [
+      {
+        "urls": ["stun:stun.intent.chat:3478"]
+      },
+      {
+        "urls": [
+          "turn:turn.intent.chat:3478?transport=udp",
+          "turn:turn.intent.chat:443?transport=tcp"
+        ],
+        "username": "1708012800:user_9876543210",
+        "credential": "a1b2c3d4e5f6..."
+      }
+    ]
+  }
+}
+```
+
+**Notes:**
+- Only sent to the user who requested the voice connection, not broadcast.
+- The `token` is a signed JWT binding user + server + channel. Must be included in the first opcode 12 offer.
+- If the token expires before use, send opcode 4 again to get a fresh one.
+- TURN credentials are time-limited (12 hour TTL). TCP on port 443 is a fallback for restrictive networks.
+- See `voice/signaling.md` for the full connection flow after receiving this event.
 
 ### MEMBER_ADD
 

--- a/gateway/messagepack.md
+++ b/gateway/messagepack.md
@@ -1,22 +1,217 @@
-# MessagePack Protocol
+# MessagePack Binary Protocol
 
-Intent uses MessagePack binary protocol for WebSocket communication.
+Intent's gateway uses [MessagePack](https://msgpack.org/) binary encoding for all WebSocket frames. Every message sent or received on the gateway is a MessagePack-encoded map, never JSON text.
 
-## Why MessagePack?
+## Why MessagePack
 
-- Smaller payload size than JSON
-- Faster serialization/deserialization
-- Binary-safe (for future binary data embedding)
+- ~30% smaller payloads than equivalent JSON
+- Faster encode/decode — no string parsing, direct binary reads
+- Native binary type for future attachment/media embedding
+- Deterministic encoding — same input always produces same bytes
 
-## Message Format
+## WebSocket Frame Requirements
+
+| Property | Value |
+|----------|-------|
+| Frame type | Binary (`0x02`), not Text (`0x01`) |
+| Compression | None (MessagePack is already compact) |
+| Max frame size | 64 KiB per message |
+| Fragmentation | Not supported — each message is a single frame |
+
+Clients that send Text frames will receive close code `4002` (decode error). Payloads exceeding 64 KiB are rejected with close code `4009` (payload too large).
+
+## Message Structure
+
+Every gateway message is a MessagePack map with string keys:
 
 ```
 {
- "op": <opcode>,
- "d": <data>,
- "s": <sequence>, // optional
- "t": <event_type> // for opcode 0
+  "op": <uint>,          // opcode — always present
+  "d":  <any | null>,    // data payload — always present (null if empty)
+  "t":  <str | null>,    // event name — present on Dispatch (op 0) only
+  "s":  <uint | null>    // sequence number — present on Dispatch (op 0) only
 }
 ```
 
- Full protocol specification in development
+All four keys are always included in server-to-client messages. Client-to-server messages only require `op` and `d`.
+
+## Type Mapping
+
+MessagePack types map to gateway fields as follows:
+
+| Field | MessagePack Type | Notes |
+|-------|-----------------|-------|
+| `op` | positive fixint (0-12) | Single byte for all current opcodes |
+| `d` | map, null, bool, or int | Depends on opcode (see opcodes.md) |
+| `t` | fixstr or nil | Event names are always < 32 chars, fit in fixstr |
+| `s` | uint 32 | Sequence numbers reset per session |
+| Snowflake IDs | fixstr | Always encoded as strings, not integers |
+| Timestamps | fixstr | ISO 8601 strings (e.g. `"2024-01-15T12:00:00Z"`) |
+| Booleans | bool (true/false) | `0xc3` / `0xc2` |
+| Null values | nil | `0xc0` |
+| Nested objects | map | String keys, values vary |
+| Arrays | array | Used for server lists in Ready, ice_servers, etc. |
+
+### Snowflake IDs Are Strings
+
+Snowflake IDs are 64-bit integers but are always encoded as MessagePack strings, not integers. This avoids precision loss in languages where integers are limited to 53 bits (JavaScript `Number`). Clients must treat IDs as opaque strings for comparison and storage.
+
+## Encoding Examples
+
+### JavaScript / TypeScript
+
+```javascript
+import { encode, decode } from '@msgpack/msgpack';
+
+// connect with binary type
+const ws = new WebSocket('wss://gateway.intent.chat');
+ws.binaryType = 'arraybuffer';
+
+// send Identify
+function send(payload) {
+  ws.send(encode(payload));
+}
+
+send({
+  op: 2,
+  d: { token: 'usr_MTIzNDU2Nzg5MC4xNzA1MzIwMDAwLmFiY2Q...' }
+});
+
+// receive and decode
+ws.onmessage = (event) => {
+  const msg = decode(new Uint8Array(event.data));
+  switch (msg.op) {
+    case 0:  // Dispatch
+      handleEvent(msg.t, msg.d, msg.s);
+      break;
+    case 3:  // Ready
+      startHeartbeat(msg.d.heartbeat_interval);
+      break;
+    case 11: // Heartbeat ACK
+      ackHeartbeat();
+      break;
+  }
+};
+```
+
+Recommended library: `@msgpack/msgpack` (pure JS, no native deps, ~4 KB gzipped).
+
+### Python
+
+```python
+import asyncio
+import websockets
+import msgpack
+
+async def connect():
+    async with websockets.connect(
+        'wss://gateway.intent.chat',
+    ) as ws:
+        # send Identify
+        await ws.send(msgpack.packb({
+            'op': 2,
+            'd': {'token': 'usr_MTIzNDU2...'},
+        }))
+
+        async for raw in ws:
+            msg = msgpack.unpackb(raw, raw=False)
+            if msg['op'] == 0:
+                handle_event(msg['t'], msg['d'], msg['s'])
+            elif msg['op'] == 3:
+                start_heartbeat(msg['d']['heartbeat_interval'])
+            elif msg['op'] == 11:
+                ack_heartbeat()
+```
+
+Recommended library: `msgpack` (C extension, fast). Use `raw=False` to decode byte strings as Python `str`.
+
+### Rust
+
+```rust
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize)]
+struct GatewayMessage {
+    op: u8,
+    d: serde_json::Value,  // flexible payload
+    #[serde(skip_serializing_if = "Option::is_none")]
+    t: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    s: Option<u32>,
+}
+
+// encode
+let msg = GatewayMessage { op: 1, d: serde_json::Value::Null, t: None, s: None };
+let bytes = rmp_serde::to_vec_named(&msg).unwrap();
+
+// decode
+let msg: GatewayMessage = rmp_serde::from_slice(&bytes).unwrap();
+```
+
+Recommended library: `rmp-serde`. Use `to_vec_named` (not `to_vec`) to encode map keys as strings rather than integer indices.
+
+## Size Comparison
+
+Heartbeat (op 1) — smallest possible message:
+
+| Format | Bytes | Encoding |
+|--------|-------|----------|
+| JSON | 19 | `{"op":1,"d":null}` |
+| MessagePack | 7 | `82 a2 6f 70 01 a1 64 c0` |
+| Savings | 63% | |
+
+Ready payload with 3 servers (typical):
+
+| Format | Approx. Bytes |
+|--------|---------------|
+| JSON | ~820 |
+| MessagePack | ~560 |
+| Savings | ~32% |
+
+Savings increase with payload size due to more efficient encoding of repeated structure.
+
+## Wire Format Reference
+
+For implementers building from scratch, here's how the key MessagePack types appear on the wire:
+
+```
+fixmap (up to 15 entries):  1000xxxx (0x80-0x8f)
+fixstr (up to 31 bytes):    101xxxxx (0xa0-0xbf)
+positive fixint (0-127):    0xxxxxxx (0x00-0x7f)
+nil:                        11000000 (0xc0)
+false:                      11000010 (0xc2)
+true:                       11000011 (0xc3)
+uint 32:                    11001110 (0xce) + 4 bytes
+str 8 (up to 255 bytes):    11011001 (0xd9) + 1 byte len + data
+map 16:                     11011110 (0xde) + 2 byte len + entries
+array 16:                   11011100 (0xdc) + 2 byte len + entries
+```
+
+A Heartbeat message encodes as:
+
+```
+82        fixmap, 2 entries
+  a2 6f 70    fixstr "op"
+  01          fixint 1
+  a1 64       fixstr "d"
+  c0          nil
+```
+
+Total: 7 bytes.
+
+## Error Handling
+
+| Close Code | Meaning | When |
+|------------|---------|------|
+| `4002` | Decode error | Malformed MessagePack, or Text frame sent instead of Binary |
+| `4003` | Not authenticated | First message was not Identify (op 2) |
+| `4009` | Payload too large | Message exceeds 64 KiB |
+
+On decode error, the server closes the connection immediately. Clients should not retry without fixing the encoding issue.
+
+## Implementation Notes
+
+- Always set `ws.binaryType = 'arraybuffer'` in browser environments. The default `'blob'` type requires an extra async conversion step.
+- MessagePack maps preserve insertion order but clients should not rely on key ordering — always access fields by name.
+- Unknown keys in server messages should be ignored, not rejected. The server may add new fields in future versions.
+- Clients must handle both fixmap and map16 for the top-level message — large Dispatch payloads (e.g. Ready with many servers) will exceed 15 map entries in `d`.

--- a/gateway/opcodes.md
+++ b/gateway/opcodes.md
@@ -454,22 +454,100 @@ The server acknowledges receipt of a heartbeat.
 
 **Status:** Not yet implemented.
 
-WebRTC signaling for voice connections (SDP offers/answers, ICE candidates).
+Carries WebRTC signaling between client and the SFU, relayed through the gateway. All voice negotiation — SDP offers/answers, ICE candidates, renegotiation, and speaking state — flows through this opcode.
 
-**Planned payload:**
+**Base payload:**
 
 ```typescript
 {
   op: 12,
   d: {
-    type: "offer" | "answer" | "ice",
-    sdp?: string,
-    candidate?: any
+    type: "offer" | "answer" | "ice" | "renegotiate" | "speaking",
+    // remaining fields depend on type
   }
 }
 ```
 
-See voice/signaling.md for full WebRTC flow when implemented.
+**Sub-types:**
+
+| Type | Direction | Purpose |
+|------|-----------|---------|
+| `offer` | Client -> Server | SDP offer to initiate or update WebRTC session |
+| `answer` | Server -> Client | SDP answer in response to an offer |
+| `ice` | Bidirectional | ICE candidate exchange |
+| `renegotiate` | Server -> Client | New SDP offer when participants join/leave |
+| `speaking` | Server -> Client | Speaking state change for a user |
+
+**type: "offer" payload:**
+
+```typescript
+{
+  op: 12,
+  d: {
+    type: "offer",
+    sdp: string,            // full SDP offer
+    voice_token: string     // from VOICE_SERVER_UPDATE, valid 60s
+  }
+}
+```
+
+**type: "answer" payload:**
+
+```typescript
+{
+  op: 12,
+  d: {
+    type: "answer",
+    sdp: string             // full SDP answer
+  }
+}
+```
+
+**type: "ice" payload:**
+
+```typescript
+{
+  op: 12,
+  d: {
+    type: "ice",
+    candidate: string,      // ICE candidate string
+    sdp_mid: string,        // media stream identification
+    sdp_mline_index: number // m= line index
+  }
+}
+```
+
+**type: "renegotiate" payload:**
+
+```typescript
+{
+  op: 12,
+  d: {
+    type: "renegotiate",
+    sdp: string,            // new SDP offer from server
+    reason: "participant_joined" | "participant_left" | "track_update"
+  }
+}
+```
+
+**type: "speaking" payload:**
+
+```typescript
+{
+  op: 12,
+  d: {
+    type: "speaking",
+    user_id: string,
+    speaking: boolean
+  }
+}
+```
+
+**Notes:**
+- The `voice_token` in the offer is a single-use JWT binding user + server + channel. Expires after 60 seconds.
+- Renegotiation happens server-initiated when participants join or leave. Client must respond with an answer.
+- Speaking state is determined server-side via RTP audio level headers (RFC 6464) with 300ms debounce.
+- See `voice/signaling.md` for the complete connection lifecycle and `voice/codecs.md` for codec requirements.
 
 ## Connection Lifecycle
 

--- a/rest-api/README.md
+++ b/rest-api/README.md
@@ -16,13 +16,14 @@ All requests require a bearer token:
 Authorization: Bearer <token>
 ```
 
+See [authentication.md](authentication.md) for token types, permission bitfields, and OAuth2 flow.
+
 ## Documentation
 
-- [**Core Resources**](resources.md) - Servers, Channels, Messages (full CRUD operations)
-- **Rate Limiting** - In development
-- **User Operations** - In development
-- **Role Management** - In development
+- [**Resources**](resources.md) — Servers, channels, messages with full CRUD operations
+- [**Authentication**](authentication.md) — Token formats, permission system, OAuth2 outline
+- [**Rate Limiting**](rate-limiting.md) — Per-route buckets, global limits, retry headers
 
 ## OpenAPI Specification
 
-OpenAPI 3.0 schema in development.
+Machine-readable OpenAPI 3.1 spec available at [`schemas/openapi.yaml`](../schemas/openapi.yaml). Use it for code generation, type extraction, and request validation.

--- a/rest-api/resources.md
+++ b/rest-api/resources.md
@@ -139,7 +139,7 @@ Returns a channel object.
 **Channel Types:**
 - `0` - Text channel
 - `1` - Voice channel
-- `2` - Announcement channel
+- `2` - Category
 
 **Errors:**
 - `401 Unauthorized` - Invalid or missing token
@@ -167,7 +167,7 @@ Creates a channel within a server. Requires `MANAGE_CHANNELS` permission.
 
 **Fields:**
 - `name` (string, required) - Channel name, 2-100 characters
-- `type` (integer, required) - Channel type (0 = text, 1 = voice, 2 = announcement)
+- `type` (integer, required) - Channel type (0 = text, 1 = voice, 2 = category)
 - `topic` (string, optional) - Channel topic, max 1024 characters
 - `position` (integer, optional) - Sorting position, defaults to bottom
 

--- a/voice/codecs.md
+++ b/voice/codecs.md
@@ -1,12 +1,103 @@
 # Voice Codecs
 
-Supported audio codecs and configurations.
+Audio codec requirements and RTP configuration for Intent voice channels.
 
-## Opus Codec
+## Opus (Required)
 
-- **Bitrate**: 64-128 kbps
-- **Sample rate**: 48 kHz
-- **Frame size**: 20ms
-- **Channels**: Stereo (downmixed to mono for SFU)
+Opus is the only supported audio codec for voice in Intent. All clients must support Opus encoding and decoding.
 
- Full codec specifications in development
+**Configuration:**
+
+| Parameter | Value | Notes |
+|-----------|-------|-------|
+| Sample rate | 48 kHz | Fixed, Opus always negotiates 48kHz in SDP |
+| Channels | 2 (stereo) | Stereo negotiated in SDP, content can be mono or stereo |
+| Frame size | 20 ms | Balance between latency and compression efficiency |
+| Bitrate | 32 - 128 kbps | Adaptive, see profiles below |
+| FEC | Enabled | Forward error correction for packet loss resilience |
+| DTX | Enabled | Discontinuous transmission, saves bandwidth during silence |
+| Payload type | 111 | Standard dynamic payload type for Opus |
+
+**Stereo handling:**
+
+The SFU forwards Opus packets as-is without decoding or re-encoding. If a client sends stereo audio (music, screen share with audio), all receivers get stereo. The SFU does not downmix to mono — it has no reason to touch the audio content.
+
+For voice-only use, set `sprop-stereo=0` in the SDP offer so the encoder produces mono frames. Keep `stereo=1` so receivers stay prepared if another participant sends stereo. Mono within a stereo-negotiated channel saves bandwidth.
+
+## SDP Codec Negotiation
+
+For the MVP, Intent voice channels only accept Opus. The SFU rejects any SDP offer that does not include Opus.
+
+**Expected m= line in SDP offer:**
+
+```
+m=audio 9 UDP/TLS/RTP/SAVPF 111
+a=rtpmap:111 opus/48000/2
+a=fmtp:111 minptime=10;useinbandfec=1;usedtx=1
+```
+
+If a client offers additional codecs alongside Opus, the SFU answers with only Opus selected. If Opus is absent from the offer, the SFU rejects the session.
+
+## RTP Header Extensions
+
+Three RTP header extensions are required:
+
+| Extension | URI | Purpose |
+|-----------|-----|---------|
+| ssrc-audio-level | `urn:ietf:params:rtp-hdrext:ssrc-audio-level` | Per-packet audio level (RFC 6464). Used by the SFU for speaking detection. |
+| transport-wide-cc | `http://www.ietf.org/id/draft-holmer-rmcat-transport-wide-cc-extensions-01` | Transport-wide sequence numbers for congestion control. |
+| sdes:mid | `urn:ietf:params:rtp-hdrext:sdes:mid` | Media identification for bundle. Required when multiple media sections share a transport. |
+
+Clients must include all three extensions in their SDP offer. The SFU will not negotiate a session without `ssrc-audio-level` and `transport-wide-cc`.
+
+**SDP extension mapping example:**
+
+```
+a=extmap:1 urn:ietf:params:rtp-hdrext:ssrc-audio-level
+a=extmap:2 http://www.ietf.org/id/draft-holmer-rmcat-transport-wide-cc-extensions-01
+a=extmap:3 urn:ietf:params:rtp-hdrext:sdes:mid
+```
+
+## RTCP Feedback
+
+The SFU uses these RTCP feedback mechanisms:
+
+| Mechanism | SDP attribute | Purpose |
+|-----------|--------------|---------|
+| NACK | `a=rtcp-fb:111 nack` | Request retransmission of lost packets |
+| Transport-CC | `a=rtcp-fb:111 transport-cc` | Bandwidth estimation via transport-wide feedback |
+| REMB | `a=rtcp-fb:111 goog-remb` | Receiver-side bitrate estimation, SFU uses this to signal senders to adjust |
+
+**NACK** allows the SFU to request retransmission of lost packets from the sender. The SFU maintains a short jitter buffer (up to 200ms) and can retransmit packets to receivers that report loss.
+
+**Transport-CC** provides per-packet arrival time feedback used by the TWCC algorithm to estimate available bandwidth. This drives the SFU's congestion control decisions.
+
+**REMB** is sent by the SFU to individual senders when a receiver is congested. The sender should reduce its Opus encoder bitrate accordingly within the 32-128 kbps range.
+
+## Opus Profiles
+
+Recommended encoder configurations. Clients default to voice mode.
+
+| Profile | Bitrate | Opus application | Use case |
+|---------|---------|-----------------|----------|
+| Voice | 64 kbps | `voip` | Default for voice chat. Optimized for speech, lowest latency. |
+| Music | 128 kbps | `audio` | Music bots, screen share with audio, DJ channels. Preserves full frequency range. |
+| Low bandwidth | 32 kbps | `voip` | Mobile on cellular, congested networks. Intelligible speech at minimum bitrate. |
+
+**Profile switching:**
+
+Clients can switch profiles at any time by reconfiguring the Opus encoder. No renegotiation is required — the SFU is codec-agnostic and forwards whatever bitrate the sender produces. The change takes effect on the next encoded frame.
+
+When the SFU sends a REMB indicating congestion, clients should drop to the low bandwidth profile until conditions improve.
+
+## Future Codecs
+
+These codecs are not supported in the current spec but are planned for video and screen share:
+
+| Codec | Use case | Priority |
+|-------|----------|----------|
+| VP8 | Video calls (baseline) | High |
+| VP9 | Video calls (improved compression) | Medium |
+| AV1 | Screen share, high-quality video | Low (hardware support still limited) |
+
+Video will use the same SDP negotiation pattern as audio, with simulcast layers so the SFU can forward appropriate quality per receiver without transcoding. Full video codec spec comes when video support lands.

--- a/voice/signaling.md
+++ b/voice/signaling.md
@@ -334,13 +334,13 @@ Authorization: Bearer <token>
   {
     "id": "us-east",
     "name": "US East",
-    "endpoint": "us-east.voice.intent.chat",
+    "endpoint": "wss://us-east.voice.intent.chat",
     "deprecated": false
   },
   {
     "id": "eu-west",
     "name": "EU West",
-    "endpoint": "eu-west.voice.intent.chat",
+    "endpoint": "wss://eu-west.voice.intent.chat",
     "deprecated": false
   }
 ]

--- a/voice/signaling.md
+++ b/voice/signaling.md
@@ -1,13 +1,595 @@
 # Voice Signaling Protocol
 
-WebRTC SDP/ICE exchange for voice channels.
+WebRTC signaling for Intent voice channels, built on a str0m-based SFU architecture.
 
-## Connection Flow
+## Architecture
 
-1. Client joins voice channel (opcode 8)
-2. Server responds with connection info (opcode 9)
-3. WebRTC SDP offer/answer exchange
-4. ICE candidate exchange
-5. Media flow begins
+Intent uses a Selective Forwarding Unit (SFU) for voice. The server receives each participant's audio stream and forwards it individually to every other participant without mixing or transcoding. This keeps server CPU low and preserves per-user volume control on the client side.
 
- Full signaling specification in development
+The SFU is built on [str0m](https://github.com/algesten/str0m), a sans-IO Rust WebRTC library. str0m handles SDP negotiation, ICE connectivity, DTLS-SRTP key exchange, and RTP packet routing. The application layer (intent-server) manages session state, permission checks, and participant lifecycle.
+
+```
+                     +------------------+
+                     |   Intent SFU     |
+                     |   (str0m)        |
+                     +------------------+
+                    /    |    |    |     \
+                   /     |    |    |      \
+              User A  User B  User C  User D  User E
+              (send)  (send)  (send)  (send)  (send)
+
+    Each user sends 1 stream to the SFU.
+    SFU forwards N-1 streams to each user.
+    No mixing, no transcoding.
+```
+
+**Why SFU over mesh or MCU:**
+
+- **Mesh** (peer-to-peer): Each client sends to every other client. Upload bandwidth scales as O(N). Breaks above 4-5 users.
+- **MCU** (mixing): Server decodes, mixes, and re-encodes a single stream per client. High CPU cost, adds latency, destroys per-user volume control.
+- **SFU** (forwarding): Each client uploads once. Server fans out without processing audio. Scales to 25 users with minimal server load. Clients decode N-1 streams but modern hardware handles that easily.
+
+Maximum participants per voice channel: **25** (24 receive streams * 64 kbps = ~1.5 Mbps downstream worst case).
+
+## Voice Connection Lifecycle
+
+Full sequence from join request to media flow:
+
+```
+Client                          Gateway                         SFU
+  |                               |                               |
+  |-- op 4: Voice State Update -->|                               |
+  |   { server_id, channel_id,   |                               |
+  |     self_mute, self_deaf }    |                               |
+  |                               |-- permission check (CONNECT) -|
+  |                               |                               |
+  |<-- VOICE_STATE_UPDATE --------|                               |
+  |   (broadcast to server)       |                               |
+  |                               |                               |
+  |<-- VOICE_SERVER_UPDATE -------|                               |
+  |   { endpoint, token,         |                               |
+  |     ice_servers }             |                               |
+  |                               |                               |
+  |-- op 12: { type: "offer" } ---------------------------------->|
+  |   (SDP offer via gateway)     |                               |
+  |                               |                               |
+  |<-- op 12: { type: "answer" } ---------------------------------|
+  |   (SDP answer via gateway)    |                               |
+  |                               |                               |
+  |-- op 12: { type: "ice" } ------------------------------------>|
+  |<-- op 12: { type: "ice" } ------------------------------------|
+  |   (ICE candidate exchange)    |                               |
+  |                               |                               |
+  |<============== DTLS-SRTP handshake =========================>|
+  |                               |                               |
+  |<============== RTP/RTCP media flow =========================>|
+  |                               |                               |
+```
+
+Steps in detail:
+
+1. **Client sends opcode 4** with the target voice channel. Gateway validates the user has `CONNECT` permission on that channel.
+2. **Gateway broadcasts VOICE_STATE_UPDATE** to all members of the server so clients can update voice user lists.
+3. **Gateway sends VOICE_SERVER_UPDATE** privately to the joining client with the SFU endpoint URL, a single-use voice token (valid 60 seconds), and STUN/TURN server configuration.
+4. **Client creates an SDP offer** for an audio-only PeerConnection and sends it via opcode 12 with `type: "offer"`.
+5. **SFU responds with an SDP answer** via opcode 12 with `type: "answer"`. The answer includes receive-only tracks for each existing participant.
+6. **ICE candidates are exchanged** via opcode 12 with `type: "ice"` in both directions until connectivity is established.
+7. **DTLS-SRTP handshake** completes, establishing encrypted media transport.
+8. **Media flows.** Client sends Opus audio to the SFU, SFU forwards audio from other participants.
+
+## Opcode 4: Voice State Update
+
+Sent by the client to join, move between, or leave voice channels. Also used to toggle self-mute and self-deaf.
+
+**Direction:** Client -> Server
+
+**Payload:**
+
+```typescript
+interface VoiceStateUpdatePayload {
+  server_id: string;           // target server
+  channel_id: string | null;   // voice channel to join, null to disconnect
+  self_mute: boolean;          // client-side mute
+  self_deaf: boolean;          // client-side deafen
+}
+```
+
+**Behaviors:**
+
+| Action | Payload | Result |
+|--------|---------|--------|
+| Join channel | `channel_id` set, not currently in voice | Permission check, SFU allocation, VOICE_STATE_UPDATE + VOICE_SERVER_UPDATE |
+| Move channel | `channel_id` set, already in different channel | Permission check on new channel, teardown old connection, new SFU session |
+| Disconnect | `channel_id: null` | Graceful disconnect, track removal, VOICE_STATE_UPDATE broadcast |
+| Toggle mute | Same `channel_id`, `self_mute` changed | VOICE_STATE_UPDATE broadcast, no media renegotiation |
+| Toggle deaf | Same `channel_id`, `self_deaf` changed | VOICE_STATE_UPDATE broadcast, server stops forwarding streams to client |
+
+**Permission checks:**
+
+- `CONNECT` is required to join any voice channel.
+- `SPEAK` is required to transmit audio. Without it, the client connects in listen-only mode.
+- Server owner bypasses all permission checks.
+
+**Error responses (via gateway close or dispatch):**
+
+- Missing `CONNECT` permission: gateway error code `4014` (voice permission denied)
+- Channel does not exist: gateway error code `4011` (unknown channel)
+- Channel is full (25 users): gateway error code `4015` (voice channel full)
+
+## Opcode 12: Voice Signal
+
+Bidirectional signaling opcode that carries WebRTC negotiation messages between the client and SFU, relayed through the gateway.
+
+**Direction:** Bidirectional
+
+**Base payload:**
+
+```typescript
+interface VoiceSignalPayload {
+  type: "offer" | "answer" | "ice" | "renegotiate" | "speaking";
+  // remaining fields depend on type
+}
+```
+
+### type: "offer"
+
+Client sends an SDP offer to initiate or update the WebRTC session.
+
+**Direction:** Client -> Server
+
+```typescript
+interface VoiceSignalOffer {
+  type: "offer";
+  sdp: string;             // full SDP offer
+  voice_token: string;     // token from VOICE_SERVER_UPDATE
+}
+```
+
+**Example:**
+
+```json
+{
+  "op": 12,
+  "d": {
+    "type": "offer",
+    "sdp": "v=0\r\no=- 4611731400430051336 2 IN IP4 127.0.0.1\r\n...",
+    "voice_token": "vt_a8f3bc91d2e4..."
+  }
+}
+```
+
+### type: "answer"
+
+Server responds to an offer with an SDP answer.
+
+**Direction:** Server -> Client
+
+```typescript
+interface VoiceSignalAnswer {
+  type: "answer";
+  sdp: string;             // full SDP answer
+}
+```
+
+**Example:**
+
+```json
+{
+  "op": 12,
+  "d": {
+    "type": "answer",
+    "sdp": "v=0\r\no=- 7614219014086345202 2 IN IP4 10.0.1.5\r\n..."
+  }
+}
+```
+
+### type: "ice"
+
+ICE candidate exchange. Sent in both directions as candidates are gathered.
+
+**Direction:** Bidirectional
+
+```typescript
+interface VoiceSignalIce {
+  type: "ice";
+  candidate: string;       // ICE candidate string (a= line)
+  sdp_mid: string;         // media stream identification tag
+  sdp_mline_index: number; // index of the m= line
+}
+```
+
+**Example:**
+
+```json
+{
+  "op": 12,
+  "d": {
+    "type": "ice",
+    "candidate": "candidate:842163049 1 udp 1677729535 203.0.113.5 24680 typ srflx raddr 192.168.1.5 rport 54321",
+    "sdp_mid": "audio",
+    "sdp_mline_index": 0
+  }
+}
+```
+
+### type: "renegotiate"
+
+Server pushes a new SDP offer when the session needs updating (participant joined/left, track added/removed). The client must respond with an answer.
+
+**Direction:** Server -> Client
+
+```typescript
+interface VoiceSignalRenegotiate {
+  type: "renegotiate";
+  sdp: string;             // new SDP offer from server
+  reason: "participant_joined" | "participant_left" | "track_update";
+}
+```
+
+**Example:**
+
+```json
+{
+  "op": 12,
+  "d": {
+    "type": "renegotiate",
+    "sdp": "v=0\r\no=- 7614219014086345202 3 IN IP4 10.0.1.5\r\n...",
+    "reason": "participant_joined"
+  }
+}
+```
+
+The client handles this by calling `setRemoteDescription` with the new offer, then generating and sending back an answer via `type: "answer"`.
+
+### type: "speaking"
+
+Indicates whether a user is currently speaking. Used for visual speaking indicators in the client UI.
+
+**Direction:** Server -> Client
+
+```typescript
+interface VoiceSignalSpeaking {
+  type: "speaking";
+  user_id: string;
+  speaking: boolean;
+}
+```
+
+**Example:**
+
+```json
+{
+  "op": 12,
+  "d": {
+    "type": "speaking",
+    "user_id": "9876543210",
+    "speaking": true
+  }
+}
+```
+
+The SFU determines speaking state using RTP audio level headers (RFC 6464). A user is considered speaking when their audio level exceeds -40 dBov. The server applies a 300ms debounce — a user must be below threshold for 300ms before a `speaking: false` is emitted. This prevents flickering indicators during natural speech pauses.
+
+## Voice Server Discovery
+
+When a client sends opcode 4 to join a voice channel, the gateway responds with a `VOICE_SERVER_UPDATE` dispatch event containing everything the client needs to connect:
+
+- **endpoint**: WebSocket URL of the SFU handling this voice session
+- **token**: Single-use voice token, valid for 60 seconds. Included in the first opcode 12 offer to authenticate with the SFU.
+- **ice_servers**: Array of STUN/TURN server configurations for NAT traversal
+
+The voice token binds to the specific user, server, and channel from the opcode 4 request. It cannot be reused or transferred.
+
+If the token expires before the client sends an offer, the client must send opcode 4 again to get a fresh VOICE_SERVER_UPDATE.
+
+## STUN/TURN Configuration
+
+Voice connections need to traverse NATs and firewalls. The `ice_servers` array in VOICE_SERVER_UPDATE provides the necessary configuration.
+
+**STUN (Session Traversal Utilities for NAT):**
+
+Used for NAT type detection and gathering server-reflexive candidates. Intent runs STUN servers colocated with voice regions. No authentication required for STUN.
+
+**TURN (Traversal Using Relays around NAT):**
+
+Relay fallback for clients behind symmetric NATs or restrictive firewalls where direct connectivity fails. TURN relays media through the server at higher latency but guarantees connectivity.
+
+TURN credentials are time-limited using HMAC-based ephemeral credentials (timestamp-prefixed username + HMAC-SHA1 shared secret). Credentials are valid for 12 hours and included directly in the `ice_servers` array.
+
+**Example ice_servers payload:**
+
+```json
+[
+  {
+    "urls": ["stun:stun.intent.chat:3478"]
+  },
+  {
+    "urls": [
+      "turn:turn.intent.chat:3478?transport=udp",
+      "turn:turn.intent.chat:443?transport=tcp"
+    ],
+    "username": "1708012800:user_9876543210",
+    "credential": "a1b2c3d4e5f6..."
+  }
+]
+```
+
+The TURN TCP transport on port 443 exists as a last-resort fallback for networks that block all UDP traffic.
+
+## REST Endpoints
+
+**GET /voice/regions**
+
+Returns available voice server regions. Clients can use this to show latency information or let users override automatic region selection.
+
+```
+GET /voice/regions
+Authorization: Bearer <token>
+```
+
+**Response: 200 OK**
+
+```json
+[
+  {
+    "id": "us-east",
+    "name": "US East",
+    "endpoint": "us-east.voice.intent.chat",
+    "deprecated": false
+  },
+  {
+    "id": "eu-west",
+    "name": "EU West",
+    "endpoint": "eu-west.voice.intent.chat",
+    "deprecated": false
+  }
+]
+```
+
+| Endpoint | Method | Description | Status |
+|----------|--------|-------------|--------|
+| `/voice/regions` | GET | List voice server regions | Planned |
+| `/voice/turn-credentials` | POST | Request fresh TURN credentials | Planned |
+
+**POST /voice/turn-credentials**
+
+Requests fresh TURN credentials outside the normal voice join flow. Useful for ICE restarts when the original credentials have expired.
+
+```
+POST /voice/turn-credentials
+Authorization: Bearer <token>
+Content-Type: application/json
+
+{
+  "server_id": "1234567890"
+}
+```
+
+**Response: 200 OK**
+
+```json
+{
+  "ice_servers": [
+    {
+      "urls": ["turn:turn.intent.chat:3478?transport=udp"],
+      "username": "1708012800:user_9876543210",
+      "credential": "f6e5d4c3b2a1..."
+    }
+  ],
+  "ttl": 43200
+}
+```
+
+## Mid-Call Participant Join
+
+When a new participant joins an active voice channel, the SFU must update all existing sessions to include the new participant's audio track.
+
+**Flow:**
+
+1. New user sends opcode 4, goes through the normal join flow (VOICE_STATE_UPDATE, VOICE_SERVER_UPDATE, offer/answer).
+2. Once the new user's WebRTC session is established, the SFU sends opcode 12 `type: "renegotiate"` with `reason: "participant_joined"` to every existing participant.
+3. Each existing participant receives a new SDP offer that includes a receive-only track for the new user.
+4. Each existing participant responds with an SDP answer.
+5. Media from the new participant starts flowing to all existing participants.
+
+This process runs in parallel for all existing participants. If any single renegotiation fails, only that participant misses the new audio track; others are unaffected.
+
+## ICE Restart
+
+ICE connectivity can degrade due to network changes (Wi-Fi to cellular, IP change, NAT rebinding). When this happens the client or server can trigger an ICE restart.
+
+**When to restart:**
+
+- Client detects ICE connection state transition to `disconnected` or `failed`
+- No media received for 10 seconds despite active speakers
+- Network interface change detected
+
+**Restart flow:**
+
+1. Client generates a new SDP offer with `iceRestart: true` in the `createOffer` options.
+2. Client sends the offer via opcode 12 `type: "offer"` (same as initial negotiation).
+3. SFU responds with a new SDP answer containing fresh ICE credentials.
+4. ICE candidate exchange proceeds again via opcode 12 `type: "ice"`.
+5. Once new connectivity is established, media resumes on the new path.
+
+**If TURN credentials have expired** during the session, the client should call `POST /voice/turn-credentials` to get fresh ones before restarting ICE.
+
+**Fallback after repeated failures:**
+
+If ICE restart fails 3 consecutive times, the client should perform a full rejoin: send opcode 4 with `channel_id: null` (disconnect), wait 1-3 seconds with jitter, then send opcode 4 again with the original channel.
+
+## Speaking Indicators
+
+The SFU detects speaking state server-side using the `ssrc-audio-level` RTP header extension defined in RFC 6464. This avoids clients needing to report their own speaking state, which would be unreliable and gameable.
+
+**Detection parameters:**
+
+- Audio level threshold: -40 dBov (levels above this indicate speech)
+- Debounce on: 0ms (speaking starts immediately when threshold exceeded)
+- Debounce off: 300ms (must be below threshold for 300ms before speaking stops)
+
+The SFU broadcasts speaking state changes via opcode 12 `type: "speaking"` to all participants in the channel except the speaker themselves (the speaker's own client knows its local state).
+
+Clients should use speaking state to drive visual indicators (glowing avatar borders, pulsing icons). Do not use speaking state for voice activity detection (VAD) gating — that should happen locally on the client before encoding.
+
+## Bitrate Adaptation
+
+The SFU uses Transport-Wide Congestion Control (TWCC) to estimate available bandwidth per receiver and adjusts forwarding accordingly.
+
+**Opus bitrate range:** 32 - 128 kbps
+
+Clients should configure their Opus encoder to use the full adaptive range. The SFU does not transcode or modify audio packets, but it can instruct clients to adjust their send bitrate via RTCP REMB (Receiver Estimated Maximum Bitrate) messages.
+
+**How it works:**
+
+1. SFU collects TWCC feedback from each receiver to estimate their downstream capacity.
+2. If a receiver is congested, the SFU sends REMB to the relevant senders, requesting a lower bitrate.
+3. Senders adjust their Opus encoder bitrate within the 32-128 kbps range.
+4. When congestion clears, REMB values increase and senders can raise their bitrate.
+
+This is per-receiver — one congested participant doesn't degrade audio quality for everyone else.
+
+## Voice State Object
+
+The authoritative representation of a user's voice connection state, broadcast in VOICE_STATE_UPDATE events.
+
+```typescript
+interface VoiceState {
+  user_id: string;          // who this state belongs to
+  server_id: string;        // which server
+  channel_id: string | null; // which voice channel, null if disconnected
+  session_id: string;       // unique session identifier for this voice connection
+  self_mute: boolean;       // user muted themselves
+  self_deaf: boolean;       // user deafened themselves
+  server_mute: boolean;     // server-side mute (by admin)
+  server_deaf: boolean;     // server-side deafen (by admin)
+}
+```
+
+**Field notes:**
+
+- `session_id` is generated when the user joins voice and remains stable across mute/deaf toggles. It changes on rejoin.
+- `server_mute` and `server_deaf` can only be set by users with `MUTE_MEMBERS` and `DEAFEN_MEMBERS` permissions respectively.
+- When `server_mute` is true, the SFU drops the user's audio packets rather than forwarding them. The client may still be encoding and sending audio, but nobody hears it.
+- When `self_deaf` or `server_deaf` is true, the SFU stops forwarding other participants' audio to that client, saving downstream bandwidth.
+
+## Disconnect and Cleanup
+
+### Graceful Disconnect
+
+Client sends opcode 4 with `channel_id: null`:
+
+1. Gateway broadcasts VOICE_STATE_UPDATE with `channel_id: null` to the server.
+2. SFU closes the client's PeerConnection and removes their tracks.
+3. SFU sends opcode 12 `type: "renegotiate"` with `reason: "participant_left"` to remaining participants.
+4. Remaining participants renegotiate to drop the leaving user's receive track.
+
+### Ungraceful Disconnect
+
+Client disappears (network failure, crash, browser tab closed):
+
+1. SFU detects no heartbeat/RTCP from the client for 15 seconds.
+2. SFU marks the session as dead and removes tracks.
+3. Gateway broadcasts VOICE_STATE_UPDATE with `channel_id: null`.
+4. Renegotiation proceeds with remaining participants as above.
+
+If the client comes back within the 15-second window and successfully restarts ICE, the session is preserved without renegotiation.
+
+### Empty Channel Cleanup
+
+When the last participant disconnects from a voice channel, the SFU tears down all session state for that channel. No resources are held for empty voice channels.
+
+## Security
+
+### Voice Token Validation
+
+The voice token from VOICE_SERVER_UPDATE is a signed JWT containing:
+
+- `user_id`: the authenticated user
+- `server_id`: the target server
+- `channel_id`: the target voice channel
+- `exp`: expiration timestamp (60 seconds from issuance)
+
+The SFU validates this token on the first opcode 12 offer. If invalid or expired, the SFU rejects the connection with a close frame.
+
+### Permission Enforcement
+
+Permissions are checked at two points:
+
+1. **On join (opcode 4):** Gateway checks `CONNECT` and `SPEAK` permissions. If the user lacks `CONNECT`, the request is rejected immediately.
+2. **Mid-call:** If a role change removes `SPEAK` from a connected user, the SFU server-mutes them. If `CONNECT` is removed, the SFU disconnects them entirely.
+
+Relevant permissions from the permission system:
+
+| Permission | Bit | Voice behavior |
+|------------|-----|----------------|
+| `CONNECT` | `1 << 20` | Required to join voice channel |
+| `SPEAK` | `1 << 21` | Required to transmit audio (listen-only without) |
+| `MUTE_MEMBERS` | `1 << 22` | Server-mute other users |
+| `DEAFEN_MEMBERS` | `1 << 23` | Server-deafen other users |
+| `MOVE_MEMBERS` | `1 << 24` | Force-move users between voice channels |
+
+### Transport Encryption
+
+All media is encrypted with SRTP (Secure Real-time Transport Protocol), negotiated during the DTLS handshake. The encryption keys are ephemeral and unique per session.
+
+The SFU terminates DTLS-SRTP — it decrypts incoming packets and re-encrypts them for each receiver with their individual session keys. This means the SFU can see unencrypted audio content. This is standard for any SFU architecture.
+
+### Future: End-to-End Encrypted Voice
+
+True E2EE voice (where the SFU cannot access audio content) will be implemented using the Insertable Streams API (WebRTC Encoded Transform). Under E2EE voice:
+
+- Clients encrypt audio frames with MLS group keys before passing them to the WebRTC stack
+- The SFU forwards the encrypted packets as-is (it cannot decrypt them)
+- Receiving clients decrypt using the shared MLS group key
+
+This builds on the MLS E2EE infrastructure defined in `encryption/mls-spec.md`. Implementation is post-Phase 1.
+
+## Summary
+
+### Opcodes
+
+| Opcode | Name | Direction | Voice role | Status |
+|--------|------|-----------|------------|--------|
+| 4 | Voice State Update | Client -> Server | Join/leave/mute/deaf | Planned |
+| 12 | Voice Signal | Bidirectional | SDP/ICE/speaking | Planned |
+
+### Dispatch Events
+
+| Event | Direction | Voice role | Status |
+|-------|-----------|------------|--------|
+| VOICE_STATE_UPDATE | Server -> Client | Broadcast voice state changes | Planned |
+| VOICE_SERVER_UPDATE | Server -> Client | Provide SFU endpoint + token | Planned |
+
+### REST Endpoints
+
+| Endpoint | Method | Description | Status |
+|----------|--------|-------------|--------|
+| `/voice/regions` | GET | List voice server regions | Planned |
+| `/voice/turn-credentials` | POST | Fresh TURN credentials for ICE restart | Planned |
+
+## Error Handling
+
+| Scenario | Error | Client action |
+|----------|-------|---------------|
+| Missing CONNECT permission | Gateway close 4014 | Show permission error, don't retry |
+| Voice channel full (25 users) | Gateway close 4015 | Show "channel full" message |
+| Channel does not exist | Gateway close 4011 | Remove channel from local state |
+| Voice token expired | SFU rejects offer | Send opcode 4 again for fresh token |
+| Voice server unreachable | SFU endpoint connection fails | Exponential backoff: 1s, 2s, 4s, 8s (max 15s) |
+| ICE failure after 3 restarts | ICE state stuck at failed | Full rejoin (disconnect + reconnect) |
+| Mid-call permission revoked | SFU disconnects or server-mutes | VOICE_STATE_UPDATE reflects new state |
+
+**Reconnection backoff:**
+
+Use jittered exponential backoff for all voice reconnection attempts. Base delay 1 second, multiplier 2x, max 15 seconds, jitter +/-25%.
+
+## Future Enhancements
+
+These are not part of the current specification but are planned for future phases:
+
+- **Video and screen share:** Additional media tracks negotiated via opcode 12 renegotiation. Video codecs (VP8/VP9/AV1) will be specified in `voice/codecs.md` when implemented. Simulcast for bandwidth adaptation.
+- **E2EE voice:** End-to-end encrypted audio using Insertable Streams and MLS group keys. See `encryption/mls-spec.md`.
+- **Stage channels:** One-to-many broadcast channels with speaker/audience roles and hand-raise mechanics.
+- **Priority speaker:** A permission-gated role that boosts one user's audio and attenuates others, for moderation or presentations.
+- **Noise suppression hints:** Server-side metadata to help clients decide whether to enable local noise suppression based on channel size and type.


### PR DESCRIPTION
## Summary

Complete voice signaling spec for issue #7. Covers the full WebRTC flow from join to media, built around str0m SFU architecture.

**What changed:**

- `voice/signaling.md` — rewrote from 13-line stub to full spec (~600 lines). SFU architecture, connection lifecycle with sequence diagram, opcode 4 behaviors, opcode 12 with all five sub-types (offer/answer/ice/renegotiate/speaking), STUN/TURN config, REST endpoints for regions and TURN creds, mid-call renegotiation, ICE restart, speaking indicators via RFC 6464, TWCC bitrate adaptation, voice state object, disconnect/cleanup, security model, error handling.
- `voice/codecs.md` — Opus-only codec spec with SDP negotiation rules, three required RTP header extensions, RTCP feedback mechanisms, three encoder profiles (voice/music/low-bw), future video codec placeholders.
- `gateway/opcodes.md` — expanded opcode 12 stub with typed payloads for all five sub-types and direction table.
- `gateway/events.md` — expanded VOICE_STATE_UPDATE (added session_id, examples, triggers) and VOICE_SERVER_UPDATE (added ice_servers array, IceServer type, full JSON example).
- `rest-api/resources.md` — fixed channel type 2 mislabel ("announcement" -> "category").

## Cross-reference verification

- All opcode 12 payloads match across signaling.md, opcodes.md
- Voice event fields match across events.md, signaling.md
- Permission names/bits match authentication.md
- No camelCase field names, no emojis
- All referenced file paths exist
- REST routes don't conflict with existing API
- Gateway close codes (4011/4014/4015) don't clash with existing codes
- Endpoint URLs use wss:// consistently

Closes #7